### PR TITLE
Fixed bug PTSDK-737.

### DIFF
--- a/lib/ripple/ui/plugins/omnibar.js
+++ b/lib/ripple/ui/plugins/omnibar.js
@@ -59,7 +59,8 @@ module.exports = {
     initialize: function (prev, baton) {
         var omnibar = _omnibar(),
             position, loc, tmp,
-            url, filename, matching;
+            url, filename, matching,
+            xhr;
 
         jQuery(".logo, .beta, .left, .right, .left-panel-collapse, .right-panel-collapse").css({
             "marginTop": "35px"
@@ -90,11 +91,29 @@ module.exports = {
         omnibar.addEventListener("keydown", function (event) {
             if (event.keyCode === '13' || event.keyCode === 13 || event.keyCode === '0' || event.keyCode === 0) { // enter or return
                 if (omnibar.value.trim() !== "") {
-                    //default the protocal if not provided
-                    omnibar.value = omnibar.value.indexOf("://") < 0 ? "http://" + omnibar.value : omnibar.value;
-                    _persist(omnibar.value);
-                    _persistRoot(omnibar.value);
-                    emulatorBridge.window().location.assign(omnibar.value);
+                    if (_currentURL().match(/^file:/) && omnibar.value.match(/^file:/)) { // Use ajax to know whether that file exists
+                        xhr = new XMLHttpRequest();
+                        xhr.onreadystatechange = function () {
+                            if (xhr.readyState == 4) {
+                                if (xhr.responseText !== '') {
+                                    _persist(omnibar.value);
+                                    _persistRoot(omnibar.value);
+                                    emulatorBridge.window().location.assign(omnibar.value);
+                                } else {
+                                    alert("File doesn't exist!");
+                                    return;
+                                }
+                            }
+                        };
+                        xhr.open('GET', omnibar.value, true);
+                        xhr.send(null);
+                    } else {
+                        //default the protocal if not provided
+                        omnibar.value = omnibar.value.indexOf("://") < 0 ? "http://" + omnibar.value : omnibar.value;
+                        _persist(omnibar.value);
+                        _persistRoot(omnibar.value);
+                        emulatorBridge.window().location.assign(omnibar.value);
+                    }
                 }
             }
         });


### PR DESCRIPTION
 When load local file that doesn't exist, do nothing but pop out alert frame.
