### PR TITLE
tune the input value of battery level automaticlly

### DIFF
--- a/lib/ripple/ui/plugins/battery.js
+++ b/lib/ripple/ui/plugins/battery.js
@@ -27,7 +27,7 @@ var event = require('ripple/event'),
         charge: function (isStart, isCharge, callback) {
             var currentVolume,
                 checkValue = function () {
-                    if (_battery.level <= 0 || _battery.level > 1.0 || !isStart) {
+                    if (_battery.level < 0 || _battery.level > 1.0 || !isStart) {
                         clearInterval(_battery.timerId);
                         _battery.timerId = null;
                         if (_battery.level < 0)
@@ -173,6 +173,11 @@ module.exports = {
         $("#stop-btn").bind("click", _stopDischarging);
 
         $("#" + constants.BATTERY.VOLUME).bind("change", function () {
+            if (_volume.value < 0)
+                _volume.value = 0;
+            else if (_volume.value > 100)
+                _volume.value = 100;
+
             _battery.level = _volume.value / 100.0;
             _triggerEvent(true, 0, Infinity, _battery.level, "chargingtimechange");
             db.save(constants.BATTERY.VOLUME, _battery.level * 100);


### PR DESCRIPTION
No public files related. With the battery level checking, any input values that not between 0 - 100 will be ignored and set to a default value, so many potential bugs are avoided.
