### PR TITLE
[Bug fixing] PTSDK-1157. Correct exception type

### DIFF
--- a/lib/ripple/platform/tizen/2.0/power.js
+++ b/lib/ripple/platform/tizen/2.0/power.js
@@ -87,6 +87,9 @@ function findListenerCB(stateObj) {
 _self = {
     request: function (resource, state) {
         var value;
+        if (typeof resource !== 'string' || typeof state !== 'string') {
+            throw new WebAPIError(errorcode.TYPE_MISMATCH_ERR);
+        }
         //Check resource
         if (!_POWER_RESOURCE.hasOwnProperty(resource)) {
             throw new WebAPIError(errorcode.INVALID_VALUES_ERR);


### PR DESCRIPTION
add the following condition:
tizen.power.request() will throw "TYPE_MISMATCH_ERR" exception
when mandatory parameter is missing
