### PR TITLE
[bug fixing] PTSDK-1393

### DIFF
--- a/lib/ripple/platform/tizen/2.0/download.js
+++ b/lib/ripple/platform/tizen/2.0/download.js
@@ -102,7 +102,7 @@ function _exec(callback, name, downloadId, arg1, arg2) {
 
 function _getDownloadObjById(id) {
     var isFound = false, backObj;
-    if (id === null || id === undefined) {
+    if (typeof id !== "number") {
         throw new WebAPIError(errorcode.TYPE_MISMATCH_ERR);
     }
     id = Number(id);


### PR DESCRIPTION
Correct error type (download API) when parameter type mismatch
