### PR TITLE
[bug fix] PTSDK-1166

### DIFF
--- a/lib/ripple/platform/tizen/2.0/download.js
+++ b/lib/ripple/platform/tizen/2.0/download.js
@@ -188,6 +188,9 @@ _self = {
         _checkDownloadParamters(downloadRequest, downloadCallback);
         downloadObj = new DownloadItem(downloadRequest, downloadCallback);
         downloadObj = _initDownloadItem(downloadObj);
+        if (downloadObj === null || downloadObj === undefined) {
+            return;
+        }
         downloadObj.state = DownloadState.DOWNLOADING;
         _downloads.push(downloadObj);
 


### PR DESCRIPTION
fix when onfail event is triggered by an invalid URL had unexpected
error in the console
