### PR TITLE
[Bug fixs] PTSDK-1337

### DIFF
--- a/lib/ripple/ui/plugins/geoView/panel.html
+++ b/lib/ripple/ui/plugins/geoView/panel.html
@@ -131,7 +131,7 @@
             </tr>
         </table>
 
-        <div id="disable_geo_panel" style="DISPLAY:none; position: absolute; z-index:800; top:0; left:0; height: 100%; width:100%; background-color:rgba(0, 0, 0, 0.2);">
+        <div id="disable_geo_panel" style="DISPLAY:none; position: absolute; z-index:800; top:120px; left:0; height: 100%; width:100%; background-color:rgba(0, 0, 0, 0.2);">
             <div  style="position: absolute; top: 45%; width: 100%">
                 <div style="position: relative; top: -50%; width: 100%">
                     <div align="center" style="padding: 6px; font-size: 22px; font-weight: bold; color: #666666; background-color:#ffffff;">Network is not available</div>


### PR DESCRIPTION
- Make the overlay not cover Timezone part of Network Management panel when network is unavialable.
