### PR TITLE
[bug fix] PTSDK-1459

### DIFF
--- a/lib/ripple/platform/tizen/2.0/nfc.js
+++ b/lib/ripple/platform/tizen/2.0/nfc.js
@@ -185,10 +185,16 @@ NFCAdapter = function () {
         }
     });
     event.on("nfc-peer-sending-ndef", function () {
+        var _records = [], rec, _ndef;
         if (isPeerConnected) {
             peer = db.retrieveObject(_NFC_PEER);
+            for(i in peer.ndef.records) {
+                rec = peer.ndef.records[i];
+                _records.push(new NDEFRecord(rec.tnf, rec.type, rec.payload, rec.id));
+            }
+            _ndef = new NDEFMessage(_records);
             if (_data.listener.onNDEFReceived) {
-                _data.listener.onNDEFReceived(peer.ndef);
+                _data.listener.onNDEFReceived(_ndef);
             }
         }
     });


### PR DESCRIPTION
fix NDEFMessage is missing toByte() method in NFCPeer
