### PR TITLE
[bug fixes] TDIS-5423 The successCallback function could not be invoked ...

### DIFF
--- a/lib/ripple/platform/tizen/2.0/push.js
+++ b/lib/ripple/platform/tizen/2.0/push.js
@@ -121,16 +121,6 @@ _self = function () {
         }
 
         appId = _getCurrentApplicationId();
-        appService = _data.service[appId];
-        if (!appService || !appService.isRegistered) {
-            if (errorCallback) {
-                window.setTimeout(function () {
-                    errorCallback(new WebAPIError(errorcode.UNKNOWN_ERR));
-                }, 1);
-            }
-            return;
-        }
-
         delete _data.service[appId];
         event.trigger("PushRequest", ["UNREGISTER", appId]);
         if (successCallback) {


### PR DESCRIPTION
...in unregisterService() method

Event if the service hasn't been registered, unregisterService()
still succeeds
