### PR TITLE
Fix cross frame Date instanceof problem

### DIFF
--- a/lib/ripple/emulatorBridge.js
+++ b/lib/ripple/emulatorBridge.js
@@ -98,6 +98,7 @@ module.exports = {
 
         marshal(window.tinyHippos, "tinyHippos");
         marshal(window.XMLHttpRequest, "XMLHttpRequest");
+        marshal(window.Date, "Date");
 
         if (currentPlatform.initialize) {
             currentPlatform.initialize(win);


### PR DESCRIPTION
When a date object is created in another frame, instanceof Date
doesn't return true. To solve this, we inject the Date function
into the device iframe.
