### PR TITLE
[bug fix] TDIS-5390, throw exception 'TYPE_MISMATCH_ERR' when setting ty...

### DIFF
--- a/lib/ripple/platform/tizen/2.0/systemsetting.js
+++ b/lib/ripple/platform/tizen/2.0/systemsetting.js
@@ -53,7 +53,7 @@ _self = function () {
             throw new WebAPIException(errorcode.TYPE_MISMATCH_ERR);
         }
         if (!_isTypeFound(type)) {
-            throw new WebAPIException(errorcode.INVALID_VALUES_ERR);
+            throw new WebAPIException(errorcode.TYPE_MISMATCH_ERR);
         }
         if (!(new TypeCoerce(t.DOMString)).match(value)) {
             throw new WebAPIException(errorcode.TYPE_MISMATCH_ERR);
@@ -80,7 +80,7 @@ _self = function () {
             throw new WebAPIException(errorcode.TYPE_MISMATCH_ERR);
         }
         if (!_isTypeFound(type)) {
-            throw new WebAPIException(errorcode.INVALID_VALUES_ERR);
+            throw new WebAPIException(errorcode.TYPE_MISMATCH_ERR);
         }
 
         if (!(new TypeCoerce(t.SuccessCallback)).match(successCallback)) {


### PR DESCRIPTION
...pe invalid.
