### PR TITLE
According to the updated spec to add units to storage object.

### DIFF
--- a/lib/ripple/platform/tizen/2.0/systeminfo.js
+++ b/lib/ripple/platform/tizen/2.0/systeminfo.js
@@ -79,7 +79,9 @@ function _getValue(aspect, successCallback) {
     }
 
     if (aspect === "STORAGE") {
-        obj = [obj];
+        obj.__defineGetter__("units", function () {
+            return [obj];
+        });
     }
 
     successCallback(obj);

--- a/lib/ripple/platform/tizen/2.0/systemsetting.js
+++ b/lib/ripple/platform/tizen/2.0/systemsetting.js
@@ -67,10 +67,11 @@ _self = function () {
 
         _systemSettings = db.retrieveObject(DBSYSTEMSETTING_KEY);
         _systemSettings[type] = value;
-
         db.saveObject(DBSYSTEMSETTING_KEY, _systemSettings);
         event.trigger("SystemSettingChanged");
-        successCallback();
+        setTimeout(function () {
+            successCallback();
+        }, 1);
     }
     function getProperty(type, successCallback, errorCallback) {
         if (arguments.length === 2) {
@@ -92,7 +93,9 @@ _self = function () {
         }
 
         _systemSettings = db.retrieveObject(DBSYSTEMSETTING_KEY);
-        successCallback(_systemSettings[type]);
+        setTimeout(function () {
+            successCallback(_systemSettings[type]);
+        }, 1);
     }
 
     function handleSubFeatures(subFeatures) {

--- a/lib/ripple/ui/plugins/omnibar.js
+++ b/lib/ripple/ui/plugins/omnibar.js
@@ -127,23 +127,23 @@ function _showHistory() {
 
 
 function _addHistory(uri) {
-    var i = 0;
-    histories = db.retrieveObject(constants.LAUNCHING_HISTORY);
-    if (histories !== undefined) {
-        for (i; i < histories.length; i++) {
-            if (uri === histories[i]) {
+    var i = 0, thehistories = db.retrieveObject(constants.LAUNCHING_HISTORY);
+    if (thehistories !== undefined) {
+        for (i; i < thehistories.length; i++) {
+            if (uri === thehistories[i]) {
                 return;
             }
         }
-
-        if (histories.length >= 20) {
-            histories.pop();
+        if (thehistories.length >= 20) {
+            thehistories.reverse();
+            thehistories.pop();
+            thehistories.reverse();
         }
     } else {
-        histories = [];
+        thehistories = [];
     }
-    histories.push(uri);
-    db.saveObject(constants.LAUNCHING_HISTORY, histories);
+    thehistories.push(uri);
+    db.saveObject(constants.LAUNCHING_HISTORY, thehistories);
 }
 
 _event.on("FrameHistoryChange", function (url) {


### PR DESCRIPTION
Added delay for callback to systemsetting apis.
Fixed "When the number of application launching history records exceed 20, the latest(should be oldest one) record will be replaced by the new one."
